### PR TITLE
feat: add minimal trading pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Futu Autotrade (Simplified)
+
+This repository contains a minimal trading pipeline used for demonstration.
+
+## 模型输入体检与常见错误
+
+`debug_probe.py` 可用于检查特征是否与模型输入一致。
+常见问题包括缺失列、NaN/Inf 以及 dtype 不符，运行体检可以生成
+`debug_report.json` 帮助定位问题。

--- a/RUN.md
+++ b/RUN.md
@@ -1,0 +1,9 @@
+# 运行指南
+
+```bash
+pip install -r requirements.txt
+python debug_probe.py --config ./config.yaml
+python stream_runner.py
+```
+
+Prometheus 指标默认暴露在 `http://localhost:8000/metrics`。

--- a/bridge.py
+++ b/bridge.py
@@ -1,0 +1,89 @@
+"""Feature bridge ensuring model input consistency."""
+from __future__ import annotations
+
+import logging
+from typing import Iterable, Tuple, Dict, Any
+
+import numpy as np
+import pandas as pd
+from prometheus_client import Gauge
+
+logger = logging.getLogger(__name__)
+
+
+class FeatureBridgeError(RuntimeError):
+    """Raised when the feature bridge cannot produce a valid input."""
+
+
+def _coerce_numeric(row: pd.DataFrame, cols: Iterable[str]) -> pd.DataFrame:
+    for col in cols:
+        row[col] = pd.to_numeric(row[col], errors="coerce")
+    return row
+
+
+def build_latest_feature_row(
+    df: pd.DataFrame,
+    feature_cols: Iterable[str],
+    *,
+    nan_gauge: Gauge | None = None,
+    return_info: bool = False,
+) -> Tuple[np.ndarray, Dict[str, Any]] | np.ndarray:
+    """Clean and align the latest feature row.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Source data frame.
+    feature_cols : Iterable[str]
+        Ordered list of required feature columns.
+    nan_gauge : Gauge, optional
+        Prometheus gauge to report NaN ratio.
+    return_info : bool, default False
+        Whether to return diagnostic information.
+
+    Returns
+    -------
+    np.ndarray
+        Array of shape ``(1, n)`` with ``float32`` dtype.
+    dict, optional
+        Diagnostic information if ``return_info`` is True.
+    """
+    if df.empty:
+        raise FeatureBridgeError("input DataFrame is empty")
+
+    cols = list(feature_cols)
+    row = df.iloc[[-1]].copy()
+
+    missing_cols = [c for c in cols if c not in row.columns]
+    for col in missing_cols:
+        row[col] = 0.0
+
+    row = row[cols]
+    row = _coerce_numeric(row, cols)
+    row = row.replace([np.inf, -np.inf], np.nan)
+
+    nan_mask = row.isna().to_numpy()
+    nan_rate = float(nan_mask.sum() / nan_mask.size)
+    if nan_gauge is not None:
+        nan_gauge.set(nan_rate)
+
+    if nan_rate > 0.0:
+        logger.warning("NaN/inf detected in features: rate=%.4f", nan_rate)
+        row = row.fillna(0.0)
+
+    arr = row.to_numpy(dtype=np.float32, copy=False)
+
+    info = {
+        "missing_cols": missing_cols,
+        "nan_rate": nan_rate,
+        "shape": tuple(arr.shape),
+        "dtype": str(arr.dtype),
+    }
+
+    if arr.shape != (1, len(cols)) or arr.dtype != np.float32:
+        raise FeatureBridgeError(
+            f"feature array invalid: missing={missing_cols}, nan_rate={nan_rate:.4f}, "
+            f"shape={arr.shape}, dtype={arr.dtype}"
+        )
+
+    return (arr, info) if return_info else arr

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,2 @@
+features:
+  cols: [price, volume]

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -1,0 +1,21 @@
+"""Data fetcher module providing market data.
+
+In absence of a real API, returns a mocked DataFrame with basic
+price and volume information.
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+
+def fetch_latest_data() -> pd.DataFrame:
+    """Fetch the latest market data.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame containing at least ``price`` and ``volume`` columns.
+    """
+    # In real usage this would connect to a broker API. Here we simply return
+    # a deterministic DataFrame for testing purposes.
+    return pd.DataFrame([{"price": 1.0, "volume": 100.0}])

--- a/debug_probe.py
+++ b/debug_probe.py
@@ -1,0 +1,60 @@
+"""Diagnostic tool for inspecting feature bridging."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import yaml
+from prometheus_client import Gauge
+
+import bridge
+import data_fetcher
+
+logger = logging.getLogger(__name__)
+
+
+def run(config_path: str) -> None:
+    with open(config_path, "r", encoding="utf-8") as f:
+        config: dict[str, Any] = yaml.safe_load(f)
+    cols = config["features"]["cols"]
+
+    df = data_fetcher.fetch_latest_data()
+    gauge = Gauge("features_nan_rate", "NaN rate of features")
+    X, info = bridge.build_latest_feature_row(df, cols, nan_gauge=gauge, return_info=True)
+
+    report = {
+        "columns": cols,
+        "dtype": info["dtype"],
+        "shape": info["shape"],
+        "missing_cols": info["missing_cols"],
+        "nan_rate": info["nan_rate"],
+    }
+
+    np.save("debug_X.npy", X)
+    with open("debug_report.json", "w", encoding="utf-8") as f:
+        json.dump(report, f, ensure_ascii=False, indent=2)
+
+    logger.info(
+        "missing=%s nan_rate=%.4f shape=%s dtype=%s",
+        info["missing_cols"],
+        info["nan_rate"],
+        info["shape"],
+        info["dtype"],
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", default="config.yaml", help="Config YAML path")
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO)
+    run(args.config)
+
+
+if __name__ == "__main__":
+    main()

--- a/model_service.py
+++ b/model_service.py
@@ -1,0 +1,30 @@
+"""Simplified model service used for demonstration and testing."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+MODEL_FILE = Path("model.json")
+
+
+def train_and_save(X: np.ndarray, y: np.ndarray) -> None:
+    """Dummy training that stores the mean of labels."""
+    model = {"bias": float(np.mean(y))}
+    MODEL_FILE.write_text(json.dumps(model))
+
+
+def load_model() -> dict[str, Any]:
+    if MODEL_FILE.exists():
+        return json.loads(MODEL_FILE.read_text())
+    return {"bias": 0.0}
+
+
+def predict_proba_one(model: dict[str, Any], x: np.ndarray) -> float:
+    """Predict probability using a simple logistic function."""
+    bias = model.get("bias", 0.0)
+    score = float(np.sum(x) + bias)
+    return float(1 / (1 + np.exp(-score)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+pandas
+pyyaml
+prometheus-client

--- a/stream_runner.py
+++ b/stream_runner.py
@@ -1,0 +1,48 @@
+"""Simplified streaming runner that fetches data, bridges features and runs a model."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import yaml
+from prometheus_client import Gauge, start_http_server
+
+import bridge
+import data_fetcher
+import model_service
+
+logger = logging.getLogger(__name__)
+
+
+def run_once(config: dict[str, Any]) -> None:
+    cols = config["features"]["cols"]
+    gauge = Gauge("features_nan_rate", "NaN rate of features")
+
+    df = data_fetcher.fetch_latest_data()
+    if df.empty:
+        logger.warning("data frame is empty before bridging")
+        return
+
+    try:
+        X, info = bridge.build_latest_feature_row(df, cols, nan_gauge=gauge, return_info=True)
+    except bridge.FeatureBridgeError as exc:
+        logger.warning("bridge failed: %s", exc)
+        raise
+
+    logger.info("bridge output shape=%s dtype=%s", info["shape"], info["dtype"])
+
+    model = model_service.load_model()
+    proba = model_service.predict_proba_one(model, X[0])
+    logger.info("prediction=%.4f", proba)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    with open("config.yaml", "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+    start_http_server(8000)
+    run_once(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pandas as pd
+from prometheus_client import Gauge
+
+import bridge
+
+
+def test_bridge_cleans_dataframe():
+    df = pd.DataFrame({"price": [1, np.nan], "other": [5, 6]})
+    cols = ["price", "volume"]
+    gauge = Gauge("test_nan_rate", "test")
+
+    X, info = bridge.build_latest_feature_row(df, cols, nan_gauge=gauge, return_info=True)
+
+    assert X.shape == (1, 2)
+    assert X.dtype == np.float32
+    assert info["missing_cols"] == ["volume"]
+    assert gauge._value.get() == info["nan_rate"]

--- a/tests/test_debug_probe.py
+++ b/tests/test_debug_probe.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+
+import data_fetcher
+import debug_probe
+
+
+def test_debug_probe_outputs(tmp_path, monkeypatch):
+    config = tmp_path / "config.yaml"
+    config.write_text("features:\n  cols: [price, volume]\n")
+
+    def mock_fetch():
+        return pd.DataFrame([{ "price": 1.0 }])
+
+    monkeypatch.setattr(data_fetcher, "fetch_latest_data", mock_fetch)
+    monkeypatch.chdir(tmp_path)
+
+    debug_probe.run(str(config))
+
+    assert (tmp_path / "debug_X.npy").exists()
+    report = json.loads((tmp_path / "debug_report.json").read_text())
+    assert "columns" in report and "nan_rate" in report

--- a/tests/test_stream_runner.py
+++ b/tests/test_stream_runner.py
@@ -1,0 +1,21 @@
+import pandas as pd
+from prometheus_client import CollectorRegistry, Gauge
+
+import data_fetcher
+import model_service
+import stream_runner
+
+
+def test_stream_runner(monkeypatch):
+    config = {"features": {"cols": ["price", "volume"]}}
+
+    registry = CollectorRegistry()
+    monkeypatch.setattr(stream_runner, "Gauge", lambda *a, **k: Gauge(*a, registry=registry, **k))
+
+    monkeypatch.setattr(data_fetcher, "fetch_latest_data", lambda: pd.DataFrame([{"price": 1.0, "volume": 2.0}]))
+    monkeypatch.setattr(model_service, "load_model", lambda: {})
+    monkeypatch.setattr(model_service, "predict_proba_one", lambda m, x: 0.5)
+
+    stream_runner.run_once(config)
+
+    assert registry.get_sample_value("features_nan_rate") == 0.0


### PR DESCRIPTION
## Summary
- add data bridge to clean DataFrame and output model-ready float32 row
- provide debug probe and stream runner with Prometheus metrics
- include unit tests and documentation for running the pipeline

## Testing
- `python -m pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement numpy)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68bba8ec0be08325b36feddf2872f0e3